### PR TITLE
`Timestamp` casing, exception propagation, `PostgresSQL` typo

### DIFF
--- a/Serilog.Sinks.PostgreSQL/LoggerConfigurationPostgreSQLExtensions.cs
+++ b/Serilog.Sinks.PostgreSQL/LoggerConfigurationPostgreSQLExtensions.cs
@@ -7,7 +7,7 @@ using Serilog.Sinks.PostgreSQL;
 
 namespace Serilog
 {
-    public static class LoggerConfigurationPostgresSQLExtensions
+    public static class LoggerConfigurationPostgreSQLExtensions
     {
         /// <summary>
         /// Default time to wait between checking for event batches.

--- a/Serilog.Sinks.PostgreSQL/Sinks/PostgreSQL/ColumnOptions.cs
+++ b/Serilog.Sinks.PostgreSQL/Sinks/PostgreSQL/ColumnOptions.cs
@@ -9,7 +9,7 @@ namespace Serilog.Sinks.PostgreSQL
             {DefaultColumnNames.RenderedMesssage,new RenderedMessageColumnWriter()},
             {DefaultColumnNames.MessageTemplate, new MessageTemplateColumnWriter()},
             {DefaultColumnNames.Level, new LevelColumnWriter()},
-            {DefaultColumnNames.TimeStamp, new TimeStampColumnWriter()},
+            {DefaultColumnNames.TimeStamp, new TimestampColumnWriter()},
             {DefaultColumnNames.Exception, new ExceptionColumnWriter()},
             {DefaultColumnNames.LogEventSerialized, new LogEventSerializedColumnWriter()}
 

--- a/Serilog.Sinks.PostgreSQL/Sinks/PostgreSQL/ColumnWriters.cs
+++ b/Serilog.Sinks.PostgreSQL/Sinks/PostgreSQL/ColumnWriters.cs
@@ -31,9 +31,9 @@ namespace Serilog.Sinks.PostgreSQL
     /// <summary>
     /// Writes timespan part
     /// </summary>
-    public class TimeStampColumnWriter : ColumnWriterBase
+    public class TimestampColumnWriter : ColumnWriterBase
     {
-        public TimeStampColumnWriter(NpgsqlDbType dbType = NpgsqlDbType.Timestamp) : base(dbType)
+        public TimestampColumnWriter(NpgsqlDbType dbType = NpgsqlDbType.Timestamp) : base(dbType)
         {
         }
 


### PR DESCRIPTION
Hi, just a couple of other things I picked up trying out the sink -

 * `EmitBatch()` can throw exceptions, if this happens the base `PeriodicBatchingSink` class will log to `SelfLog` as was being done here, but will also retry batches (i.e. to recover from network connectivity issues)
 * Serilog and the Postgres column types enum use `Timestamp` casing, rather than `TimeStamp`
 * There was an extra `s` in the name of `LoggerConfigurationPostgreSQLExtensions`

HTH!
Nick