### PR TITLE
Fix empty properties serialization

### DIFF
--- a/Serilog.Sinks.PostgreSQL/Sinks/PostgreSQL/ColumnWriters.cs
+++ b/Serilog.Sinks.PostgreSQL/Sinks/PostgreSQL/ColumnWriters.cs
@@ -127,6 +127,9 @@ namespace Serilog.Sinks.PostgreSQL
 
         private object PropertiesToJson(LogEvent logEvent)
         {
+            if (logEvent.Properties.Count == 0)
+                return "{}";
+
             var valuesFormatter = new JsonValueFormatter();
 
             var sb = new StringBuilder();
@@ -145,7 +148,7 @@ namespace Serilog.Sinks.PostgreSQL
                 }
             }
 
-            sb.Remove(sb.Length - 2, 1);
+            sb.Remove(sb.Length - 2, 2);
             sb.Append("}");
 
             return sb.ToString();


### PR DESCRIPTION
Hi
When you try to log simple string without properties, line `sb.Remove(sb.Length - 2, 1);` throws _System.ArgumentOutOfRangeException: „StartIndex cannot be less than zero.”_.
I fixed this issue by checking count of properties at the beginning of function.
I also changed number of removed characters to 2 (because `", "`).

