### PR TITLE
Case-sensitive when creating table

### DIFF
--- a/Serilog.Sinks.PostgreSQL.IntegrationTests/DbHelper.cs
+++ b/Serilog.Sinks.PostgreSQL.IntegrationTests/DbHelper.cs
@@ -11,14 +11,16 @@ namespace Serilog.Sinks.PostgreSQL.IntegrationTests
             _connectionString = connectionString;
         }
 
-        public void RemoveTable(string tableName)
+        public void RemoveTable(string tableName, bool respectCase = false)
         {
             using (var conn = new NpgsqlConnection(_connectionString))
             {
                 conn.Open();
                 using (var command = conn.CreateCommand())
                 {
-                    command.CommandText = $"DROP TABLE IF EXISTS {tableName}";
+                    command.CommandText = respectCase
+                        ? $"DROP TABLE IF EXISTS \"{tableName}\""
+                        : $"DROP TABLE IF EXISTS {tableName}";
 
                     command.ExecuteNonQuery();
                 }
@@ -39,10 +41,11 @@ namespace Serilog.Sinks.PostgreSQL.IntegrationTests
             }
         }
 
-        public long GetTableRowsCount(string tableName)
+        public long GetTableRowsCount(string tableName, bool respectCase = false)
         {
-            var sql = $@"SELECT count(*)
-                         FROM {tableName}";
+            var sql = respectCase
+                ? $"SELECT count(*) FROM \"{tableName}\""
+                : $"SELECT count(*) FROM {tableName}";
 
             using (var conn = new NpgsqlConnection(_connectionString))
             {

--- a/Serilog.Sinks.PostgreSQL.IntegrationTests/DbWriteTests.cs
+++ b/Serilog.Sinks.PostgreSQL.IntegrationTests/DbWriteTests.cs
@@ -190,5 +190,46 @@ namespace Serilog.Sinks.PostgreSQL.IntegrationTests
 
             Assert.Equal(rowsCount, actualRowsCount);
         }
+
+        [Fact]
+        public void AutoCreateTableIsTrueAndRespectCaseIsTrue_ShouldCreateTable()
+        {
+            var tableName = "Logs_Auto_Created";
+
+            _dbHelper.RemoveTable(tableName, respectCase: true);
+
+            var testObject = new TestObjectType1 { IntProp = 42, StringProp = "Test" };
+
+            var testObj2 = new TestObjectType2 { DateProp1 = DateTime.Now, NestedProp = testObject };
+
+            var columnProps = new Dictionary<string, ColumnWriterBase>
+            {
+                {"Message", new RenderedMessageColumnWriter() },
+                {"MessageTemplate", new MessageTemplateColumnWriter() },
+                {"Level", new LevelColumnWriter(true, NpgsqlDbType.Varchar) },
+                {"RaiseDate", new TimestampColumnWriter() },
+                {"Exception", new ExceptionColumnWriter() },
+                {"Properties", new LogEventSerializedColumnWriter() },
+                {"PropsTest", new PropertiesColumnWriter(NpgsqlDbType.Text) },
+                {"MachineName", new SinglePropertyColumnWriter("MachineName", format: "l") }
+            };
+
+            var logger =
+                new LoggerConfiguration().WriteTo.PostgreSQL(_connectionString, tableName, columnProps, needAutoCreateTable: true, respectCase: true)
+                    .Enrich.WithMachineName()
+                    .CreateLogger();
+
+            int rowsCount = 50;
+            for (int i = 0; i < rowsCount; i++)
+            {
+                logger.Information("Test{testNo}: {@testObject} test2: {@testObj2} testStr: {@testStr:l}", i, testObject, testObj2, "stringValue");
+            }
+
+            logger.Dispose();
+
+            var actualRowsCount = _dbHelper.GetTableRowsCount(tableName, respectCase: true);
+
+            Assert.Equal(rowsCount, actualRowsCount);
+        }
     }
 }

--- a/Serilog.Sinks.PostgreSQL/LoggerConfigurationPostgreSQLExtensions.cs
+++ b/Serilog.Sinks.PostgreSQL/LoggerConfigurationPostgreSQLExtensions.cs
@@ -29,6 +29,7 @@ namespace Serilog
         /// <param name="useCopy">If true inserts data via COPY command, otherwise uses INSERT INTO satement </param>
         /// <param name="schemaName">Schema name</param>
         /// <param name="needAutoCreateTable">Set if sink should create table</param>
+        /// <param name="respectCase">When needAutoCreateTable is true, indicates whether the table name and the column names respect the case.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         public static LoggerConfiguration PostgreSQL(this LoggerSinkConfiguration sinkConfiguration,
             string connectionString,
@@ -41,7 +42,8 @@ namespace Serilog
             LoggingLevelSwitch levelSwitch = null,
             bool useCopy = true,
             string schemaName = "",
-            bool needAutoCreateTable = false)
+            bool needAutoCreateTable = false,
+            bool respectCase = false)
         {
             if (sinkConfiguration == null)
             {
@@ -59,7 +61,8 @@ namespace Serilog
                                                                 batchSizeLimit,
                                                                 useCopy,
                                                                 schemaName,
-                                                                needAutoCreateTable), restrictedToMinimumLevel, levelSwitch);
+                                                                needAutoCreateTable,
+                                                                respectCase), restrictedToMinimumLevel, levelSwitch);
         }
 
     }


### PR DESCRIPTION
Hi,

Thanks for this sink, it is great!

In my case, all my tables and column names must be Pascal case.
But when the table is created, the table & colums names are lowercase letters.

To respect the case-sensitive we need to use double quotes around the names.

Here the Pull Request to add this feature.
By default, the behavior is not modified (not to create breaking change with the current one)