### PR TITLE
Adjusted Timestamp to TimestampTz in TimestampColumnWriter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ IDictionary<string, ColumnWriterBase> columnWriters = new Dictionary<string, Col
     {"message", new RenderedMessageColumnWriter(NpgsqlDbType.Text) },
     {"message_template", new MessageTemplateColumnWriter(NpgsqlDbType.Text) },
     {"level", new LevelColumnWriter(true, NpgsqlDbType.Varchar) },
-    {"raise_date", new TimestampColumnWriter(NpgsqlDbType.Timestamp) },
+    {"raise_date", new TimestampColumnWriter(NpgsqlDbType.TimestampTz) },
     {"exception", new ExceptionColumnWriter(NpgsqlDbType.Text) },
     {"properties", new LogEventSerializedColumnWriter(NpgsqlDbType.Jsonb) },
     {"props_test", new PropertiesColumnWriter(NpgsqlDbType.Jsonb) },

--- a/Serilog.Sinks.PostgreSQL.Tests/ColumnWritersTests/TimestampColumnWriterTest.cs
+++ b/Serilog.Sinks.PostgreSQL.Tests/ColumnWritersTests/TimestampColumnWriterTest.cs
@@ -10,7 +10,7 @@ namespace Serilog.Sinks.PostgreSQL.Tests
     public class TimestampColumnWriterTest
     {
         [Fact]
-        public void ByDefault_ShouldReturnTimestampValueWithoutTimezone()
+        public void ByDefault_ShouldReturnTimestampValueWithTimezone()
         {
             var writer = new TimestampColumnWriter();
 
@@ -20,7 +20,7 @@ namespace Serilog.Sinks.PostgreSQL.Tests
 
             var result = writer.GetValue(testEvent);
 
-            Assert.Equal(timeStamp.DateTime, result);
+            Assert.Equal(timeStamp, result);
         }
 
         [Fact]

--- a/Serilog.Sinks.PostgreSQL/Sinks/PostgreSQL/ColumnWriters.cs
+++ b/Serilog.Sinks.PostgreSQL/Sinks/PostgreSQL/ColumnWriters.cs
@@ -11,7 +11,7 @@ namespace Serilog.Sinks.PostgreSQL
         /// <summary>
         /// Column type
         /// </summary>
-        public NpgsqlDbType DbType { get; }
+        public NpgsqlDbType DbType { get; set;}
 
         protected ColumnWriterBase(NpgsqlDbType dbType)
         {
@@ -33,17 +33,13 @@ namespace Serilog.Sinks.PostgreSQL
     /// </summary>
     public class TimestampColumnWriter : ColumnWriterBase
     {
-        public TimestampColumnWriter(NpgsqlDbType dbType = NpgsqlDbType.Timestamp) : base(dbType)
+        public TimestampColumnWriter(NpgsqlDbType dbType = NpgsqlDbType.TimestampTz) : base(dbType)
         {
+            this.DbType = NpgsqlDbType.TimestampTz;
         }
 
         public override object GetValue(LogEvent logEvent, IFormatProvider formatProvider = null)
         {
-            if (DbType == NpgsqlDbType.Timestamp)
-            {
-                return logEvent.Timestamp.DateTime;
-            }
-
             return logEvent.Timestamp;
         }
     }


### PR DESCRIPTION
Fixes https://github.com/b00ted/serilog-sinks-postgresql/issues/27.